### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -3,6 +3,9 @@
 
 name: Node.js CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/kastel-security/polyas-core3-second-device-verification/security/code-scanning/1](https://github.com/kastel-security/polyas-core3-second-device-verification/security/code-scanning/1)

To fix this issue, we need to add a `permissions` key to the workflow. Since the workflow involves running tests, linting, and building the application, it likely does not require extensive permissions. The minimal permissions required should be limited to `contents: read`. This ensures that the workflow can access the repository contents but cannot perform write operations. 

Changes will be applied at the root level of the workflow to ensure all jobs inherit the same permissions unless overridden at the job level.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
